### PR TITLE
Refactor lib to make use of an instance of a new OpenNodeClient class

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -1,178 +1,71 @@
 const axios = require('axios');
 const crypto = require('crypto');
-const version = 'npm-opennode-v1.2.0';
+const OpenNodeClient = require('../submodules/client')
 var instance = undefined;
-var api_key;
-var env;
 
 
 function setCredentials(key = '', environment = 'live') {
   if (instance !== undefined) return;
 
-  api_key = key;
-  instance = axios.create();
-  env = environment;
-  instance.defaults.baseURL = (environment === 'live') ? 'https://api.opennode.com/v1' : 'https://dev-api.opennode.com/v1';
-  instance.defaults.timeout = 15000;
-  instance.defaults.headers = { 'Authorization' : api_key, 'user_agent' : version };
+  instance = new OpenNodeClient(key, environment);
 }
 
 async function createCharge(charge) {
-  try {
-
-    const response = await instance.post(`/charges`, charge);
-    return response.data.data;
-
-  } catch (error) {
-    throw Exception(error.response.status, error.response.statusText, error.response.data.message);
-  }
+  return await instance.createCharge(charge);
 }
 
 async function chargeInfo(id) {
-  try {
-    const response = await instance.get(`/charge/${id}`);
-    return response.data.data;
-
-  } catch (error) {
-    throw Exception(error.response.status, error.response.statusText, error.response.data.message);
-  }
+  return await instance.chargeInfo(id);
 }
 
 async function listCharges() {
-  try {
-
-    const response = await instance.get(`/charges`);
-    return response.data.data;
-
-  } catch (error) {
-    throw Exception(error.response.status, error.response.statusText, error.response.data.message);
-  }
+  return await instance.listCharges();
 }
 
 async function initiateWithdrawal(withdrawal) {
-  try {
-    console.warn(`This method is deprecated and not recommend for use. Please use the asynchronous version (initiateWithdrawalAsync)`);
-
-    const response = await instance.post(`/withdrawals`, withdrawal);
-    return response.data.data;
-
-  } catch (error) {
-    throw Exception(error.response.status, error.response.statusText, error.response.data.message);
-  }
+  console.warn(`This method is deprecated and not recommend for use. Please use the asynchronous version (initiateWithdrawalAsync)`);
+  return await instance.initiateWithdrawal(withdrawal);
 }
 
 async function withdrawalInfo(id) {
-  try {
-
-    const response = await instance.get(`/withdrawal/${id}`);
-    return response.data.data;
-
-  } catch (error) {
-    throw Exception(error.response.status, error.response.statusText, error.response.data.message);
-  }
+  return await instance.withdrawalInfo(id);
 }
 
 async function listWithdrawals() {
-  try {
-
-    const response = await instance.get(`/withdrawals`);
-    return response.data.data;
-
-  } catch (error) {
-    throw Exception(error.response.status, error.response.statusText, error.response.data.message);
-  }
+  return await instance.listWithdrawals();
 }
 
 async function listRates() {
-  try {
-
-    const response = await instance.get(`/rates`);
-    return response.data.data;
-
-  } catch (error) {
-    throw Exception(error.response.status, error.response.statusText, error.response.data.message);
-  }
+  return await instance.listRates();
 }
 
 async function listCurrencies() {
-  try {
-
-    const response = await instance.get(`/currencies`);
-    return response.data.data;
-
-  } catch (error) {
-    throw Exception(error.response.status, error.response.statusText, error.response.data.message);
-  }
+  return await instance.listCurrencies();
 }
 
 async function userBalance() {
-  try {
-    const response = await instance.get(`/account/balance`);
-    return response.data.data;
-  }
-  catch (error) {
-    throw Exception(error.response.status, error.response.statusText, error.response.data.message);
-  }
+  return await instance.userBalance();
 }
 
 async function initiateWithdrawalAsync(withdrawal) {
-  try {
-    let new_instance = axios.create();
-    new_instance.defaults.baseURL = (env === 'live') ? 'https://api.opennode.com/v2' : 'https://dev-api.opennode.com/v2';
-    new_instance.defaults.timeout = 15000;
-    new_instance.defaults.headers = { 'Authorization' : api_key, 'user_agent' : version };
-
-    const response = await new_instance.post('/withdrawals', withdrawal);
-    return response.data.data;
-  }
-  catch (error) {
-    throw Exception(error.response.status, error.response.statusText, error.response.data.message);
-  }
+  return await instance.initiateWithdrawalAsync(withdrawal);
 }
 
 async function verifySignature(charge) {
-  const hash = crypto.createHmac('sha256', api_key).update(charge.id).digest('hex');
-  return hash === charge.hashed_order;
+  return await instance.verifySignature(charge);
 }
 
 async function refundCharge(refund) {
-  try {
-    const response = await instance.post(`/refunds`, refund);
-    return response.data.data;
-  }
-  catch (error) {
-    throw Exception(error.response.status, error.response.statusText, error.response.data.message);
-  }
+  return await instance.refundCharge(refund);
 }
 
 async function listRefunds() {
-  try {
-    const response = await instance.get(`/refunds`);
-    return response.data.data;
-  }
-  catch (error) {
-    throw Exception(error.response.status, error.response.statusText, error.response.data.message);
-  }
+  return await instance.listRefunds();
 }
 
 async function refundInfo(id) {
-  try {
-    const response = await instance.get(`/refund/${id}`);
-    return response.data.data;
-  }
-  catch (error) {
-    throw Exception(error.response.status, error.response.statusText, error.response.data.message);
-  }
+  return await instance.refundInfo(id);
 }
-
-function Exception(statusCode, statusText, message) {
-  var error = new Error(message);
-  error.name = statusText;
-  error.status = statusCode;
-
-  return error;
-}
-
 
 module.exports = {
   setCredentials: setCredentials,

--- a/src/lib.js
+++ b/src/lib.js
@@ -21,7 +21,6 @@ async function listCharges() {
 }
 
 async function initiateWithdrawal(withdrawal) {
-  console.warn(`This method is deprecated and not recommend for use. Please use the asynchronous version (initiateWithdrawalAsync)`);
   return await instance.initiateWithdrawal(withdrawal);
 }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,5 +1,3 @@
-const axios = require('axios');
-const crypto = require('crypto');
 const OpenNodeClient = require('../submodules/client')
 var instance = undefined;
 

--- a/submodules/client.js
+++ b/submodules/client.js
@@ -1,9 +1,6 @@
 const axios = require('axios');
 const crypto = require('crypto');
 const version = 'npm-opennode-v1.2.0';
-var instance = undefined;
-var api_key;
-var env;
 
 
 class OpenNodeClient {

--- a/submodules/client.js
+++ b/submodules/client.js
@@ -1,0 +1,177 @@
+const axios = require('axios');
+const crypto = require('crypto');
+const version = 'npm-opennode-v1.2.0';
+var instance = undefined;
+var api_key;
+var env;
+
+
+class OpenNodeClient {
+  constructor(key = '', environment = 'live') {
+    this.api_key = key;
+    this.instance = axios.create();
+    this.env = environment;
+    this.instance.defaults.baseURL = (environment === 'live') ? 'https://api.opennode.com/v1' : 'https://dev-api.opennode.com/v1';
+    this.instance.defaults.timeout = 15000;
+    this.instance.defaults.headers = { 'Authorization': this.api_key, 'user_agent': version };
+  }
+
+  async createCharge(charge) {
+    try {
+
+      const response = await this.instance.post(`/charges`, charge);
+      return response.data.data;
+
+    } catch (error) {
+      throw Exception(error.response.status, error.response.statusText, error.response.data.message);
+    }
+  }
+
+  async chargeInfo(id) {
+    try {
+      const response = await this.instance.get(`/charge/${id}`);
+      return response.data.data;
+
+    } catch (error) {
+      throw Exception(error.response.status, error.response.statusText, error.response.data.message);
+    }
+  }
+
+  async listCharges() {
+    try {
+
+      const response = await this.instance.get(`/charges`);
+      return response.data.data;
+
+    } catch (error) {
+      throw Exception(error.response.status, error.response.statusText, error.response.data.message);
+    }
+  }
+
+  async initiateWithdrawal(withdrawal) {
+    try {
+      console.warn(`This method is deprecated and not recommend for use. Please use the asynchronous version (initiateWithdrawalAsync)`);
+
+      const response = await this.instance.post(`/withdrawals`, withdrawal);
+      return response.data.data;
+
+    } catch (error) {
+      throw Exception(error.response.status, error.response.statusText, error.response.data.message);
+    }
+  }
+
+  async withdrawalInfo(id) {
+    try {
+
+      const response = await this.instance.get(`/withdrawal/${id}`);
+      return response.data.data;
+
+    } catch (error) {
+      throw Exception(error.response.status, error.response.statusText, error.response.data.message);
+    }
+  }
+
+  async listWithdrawals() {
+    try {
+
+      const response = await this.instance.get(`/withdrawals`);
+      return response.data.data;
+
+    } catch (error) {
+      throw Exception(error.response.status, error.response.statusText, error.response.data.message);
+    }
+  }
+
+  async listRates() {
+    try {
+
+      const response = await this.instance.get(`/rates`);
+      return response.data.data;
+
+    } catch (error) {
+      throw Exception(error.response.status, error.response.statusText, error.response.data.message);
+    }
+  }
+
+  async listCurrencies() {
+    try {
+
+      const response = await this.instance.get(`/currencies`);
+      return response.data.data;
+
+    } catch (error) {
+      throw Exception(error.response.status, error.response.statusText, error.response.data.message);
+    }
+  }
+
+  async userBalance() {
+    try {
+      const response = await this.instance.get(`/account/balance`);
+      return response.data.data;
+    }
+    catch (error) {
+      throw Exception(error.response.status, error.response.statusText, error.response.data.message);
+    }
+  }
+
+  async initiateWithdrawalAsync(withdrawal) {
+    try {
+      let new_instance = axios.create();
+      new_instance.defaults.baseURL = (this.env === 'live') ? 'https://api.opennode.com/v2' : 'https://dev-api.opennode.com/v2';
+      new_instance.defaults.timeout = 15000;
+      new_instance.defaults.headers = { 'Authorization': this.api_key, 'user_agent': version };
+
+      const response = await new_instance.post('/withdrawals', withdrawal);
+      return response.data.data;
+    }
+    catch (error) {
+      throw Exception(error.response.status, error.response.statusText, error.response.data.message);
+    }
+  }
+
+  async verifySignature(charge) {
+    const hash = crypto.createHmac('sha256', this.api_key).update(charge.id).digest('hex');
+    return hash === charge.hashed_order;
+  }
+
+  async refundCharge(refund) {
+    try {
+      const response = await this.instance.post(`/refunds`, refund);
+      return response.data.data;
+    }
+    catch (error) {
+      throw Exception(error.response.status, error.response.statusText, error.response.data.message);
+    }
+  }
+
+  async listRefunds() {
+    try {
+      const response = await this.instance.get(`/refunds`);
+      return response.data.data;
+    }
+    catch (error) {
+      throw Exception(error.response.status, error.response.statusText, error.response.data.message);
+    }
+  }
+
+  async refundInfo(id) {
+    try {
+      const response = await this.instance.get(`/refund/${id}`);
+      return response.data.data;
+    }
+    catch (error) {
+      throw Exception(error.response.status, error.response.statusText, error.response.data.message);
+    }
+  }
+}
+
+function Exception(statusCode, statusText, message) {
+  var error = new Error(message);
+  error.name = statusText;
+  error.status = statusCode;
+
+  return error;
+}
+
+
+module.exports = OpenNodeClient;

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 const { assert, expect } = require('chai');
 const opennode = require('../src/lib');
+const client = require('../submodules/client');
 opennode.setCredentials('1f758b02-3405-45cf-8d71-f4462282a7ca', 'dev');
 
 describe('charge', function() {
@@ -231,5 +232,28 @@ describe('refunds', function() {
         expect(refunds).to.an('array');
       }
     });
+  });
+});
+
+describe('client', function () {
+  it('should allow multiple clients with different credentials', async () => {
+
+    let charge1, charge2, err
+    const client1 = new client('1f758b02-3405-45cf-8d71-f4462282a7ca', 'dev');
+    const charge1Id = '47bb5224-bf50-49d0-a317-4adfd345221a';
+    const client2 = new client('195d82c3-96de-43a3-9de2-13fc7fca7c7c', 'dev');
+    const charge2Id = 'd09fc8f0-8d51-4292-adeb-f8dd951fb7e6';
+
+    try {
+      charge1 = await client1.chargeInfo(charge1Id);
+      charge2 = await client2.chargeInfo(charge2Id);
+    } catch (error) {
+      err = error;
+    }
+    finally {
+      expect(err).to.be.an('undefined');
+      assert.deepEqual(charge1.id, charge1Id);
+      assert.deepEqual(charge2.id, charge2Id);
+    }
   });
 });


### PR DESCRIPTION
Implements #6 while still allowing the existing usage to remain the same.

Users can additionally leverage the new OpenNodeClient, allowing them to use multiple API keys w/ multiple clients:

```
OpenNodeClient = require('opennode/submodules/client');
const client1 = new OpenNodeClient('key-1');
const client2 = new OpenNodeClient('key-2', 'dev');

try {
  const charge = await client1.createCharge({
    amount: 10.5,
    currency: "USD",
    callback_url: "https://example.com/webhook/opennode",
    auto_settle: false
  });
}
catch (error) {
  console.error(`${error.status} | ${error.message}`);
}
try {
  const charge = await client2.createCharge({
    amount: 10.5,
    currency: "USD",
    callback_url: "https://example.com/webhook/opennode",
    auto_settle: false
  });
}
catch (error) {
  console.error(`${error.status} | ${error.message}`);
}
```