### PR TITLE
Updated axios version to patch SSRF vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "main": "src/lib.js",
   "version": "1.2.1",
   "dependencies": {
-    "axios": "^0.18.0"
+    "axios": "^0.21.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Updated axios version in package.json to ^0.21.1, to patch a Server-Side Request Forgery (SSRF) vulnerability as advised in the link below.
This should fix the vulnerability report that appears when `npm install` -ing the package.

[npmjs advisory here](https://www.npmjs.com/advisories/1594)