### PR TITLE
upgrade to v2 endpoint

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
 *.log
 npm-debug.log*
+.pnpm-store
+test-local.ts
 
 # Coverage directory used by tools like istanbul
 coverage
@@ -16,7 +18,6 @@ yarn.lock
 # project files
 test
 examples
-CHANGELOG.md
 .babelrc
 .DS_Store
 .editorconf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2026-02-05
+
+### ⚠️ BREAKING CHANGES
+
+- `chargeInfo()` now uses V2 endpoint (`/v2/charge/{id}`) with a different response shape:
+  - `amount` → `price` (amount in satoshis)
+  - `lightning_invoice` → `lightning` (full invoice object with additional fields)
+  - `transactions` → `onchain` (on-chain payment details)
+  - Timestamps now ISO 8601 format (`"2026-02-05T17:50:33.004Z"`) instead of Unix timestamps
+
+### Added
+
+- Top-level `expires_at` field - ISO timestamp when we stop monitoring for payments
+- `lightning.id` - unique identifier for the lightning invoice
+- `lightning.status` - invoice status (`pending`, `paid`, `expired`)
+- `lightning.checkout_id` - parent charge ID
+- `lightning.settled_at` - ISO timestamp when payment was received
+- JSDoc descriptions for all `OpenNodeChargeV2` fields
+- TypeScript types for V2 API responses (`OpenNodeChargeV2`)
+
+### Fixed
+
+- `fiat_value` now returns correct value (was incorrect in V1 response)
+- `source_fiat_value` now returns correct value (was incorrect in V1 response)
+- `auto_settle` now returns correct value (was incorrect in V1 response)
+
+### Migration Guide
+
+```diff
+// Field name changes
+- charge.amount
++ charge.price
+
+- charge.lightning_invoice
++ charge.lightning
+
+- charge.lightning_invoice.payreq
++ charge.lightning.payreq
+
+- charge.transactions
++ charge.onchain
+
+// Timestamp format changes
+- charge.created_at  // 1770313833 (Unix)
++ charge.created_at  // "2026-02-05T17:50:33.004Z" (ISO)
+
+// New fields
++ charge.expires_at           // when charge expires
++ charge.lightning.id         // invoice ID
++ charge.lightning.status     // invoice status
++ charge.lightning.settled_at // when paid
+```
+
+## [1.x.x] and earlier
+
+See [GitHub releases](https://github.com/opennodedev/opennode-node/releases) for previous versions.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "opennode"
   ],
   "main": "dist/index.js",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "dependencies": {
     "axios": "^1.3.4"
   },

--- a/src/client.ts
+++ b/src/client.ts
@@ -76,8 +76,8 @@ export class OpenNodeClient {
     return this.instanceV1.post(`/charges`, charge);
   }
 
-  async chargeInfo(id: string): Promise<OpenNodeCharge> {
-    return this.instanceV1.get(`/charge/${id}`);
+  async chargeInfo(id: string): Promise<v2.OpenNodeChargeV2> {
+    return this.instanceV2.get(`/charges/${id}`);
   }
 
   async listCharges(): Promise<OpenNodeCharge[]> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export function createCharge(
   return instance.createCharge(charge);
 }
 
-export function chargeInfo(id: string): Promise<v1.OpenNodeCharge> {
+export function chargeInfo(id: string): Promise<v2.OpenNodeChargeV2> {
   return instance.chargeInfo(id);
 }
 

--- a/src/types/v2.ts
+++ b/src/types/v2.ts
@@ -166,3 +166,69 @@ export interface OpenNodeLnURLWithdrawalRequest {
   external_id?: string;
   expiry_date?: number;
 }
+
+export interface OpenNodeLightningInvoice {
+  id: string;
+  status: string;
+  price: number;
+  payreq: string;
+  created_at: string;
+  expires_at: string;
+  settled_at: string | null;
+  checkout_id: string;
+}
+
+export interface OpenNodeChargeV2 {
+  /** Unique charge identifier */
+  id: string;
+  /** Charge description provided at creation */
+  description: string;
+  /** Amount in satoshis */
+  price: number;
+  /** Charge status: unpaid, paid, processing, underpaid, refunded, expired, failed */
+  status: string;
+  /** ISO timestamp when charge was created */
+  created_at: string;
+  /** ISO timestamp when charge expires and we stop monitoring for payments */
+  expires_at: string;
+  /** OpenNode fee in satoshis */
+  fee: number;
+  /** Value in merchant's account currency (e.g., if account is USD, this is in USD) */
+  fiat_value: number;
+  /** Original charge amount in the currency specified at creation */
+  source_fiat_value: number;
+  /** Currency code specified when creating the charge (e.g., USD, EUR) */
+  currency: string;
+  /** Whether the charge is configured to auto-settle to fiat */
+  auto_settle: boolean;
+  /** Optional notes attached to the charge */
+  notes: string | null;
+  /** Merchant's order ID if provided */
+  order_id: string | null;
+  /** On-chain payment details */
+  onchain: unknown[];
+  /** Lightning invoice details */
+  lightning: OpenNodeLightningInvoice | null;
+  /** Custom metadata provided at charge creation */
+  metadata: Record<string, unknown>;
+  /** Bitcoin address for on-chain payments */
+  address: string;
+  /** Whether the charge was exchanged to fiat */
+  exchanged: boolean;
+  /** Net fiat value after fees */
+  net_fiat_value: number;
+  /** Remaining amount in satoshis (for underpaid charges) */
+  missing_amt: number;
+  /** ISO timestamp when charge was settled, null if not yet settled */
+  settled_at: string | null;
+  /** Payment method used: lightning, onchain, or null if unpaid */
+  payment_method: string | null;
+  /** Time-to-live in minutes */
+  ttl: number;
+  /** Whether description hash was used for the lightning invoice */
+  desc_hash: boolean;
+  /** URL to the hosted checkout page */
+  hosted_checkout_url: string;
+  /** Customer site ID if applicable */
+  customer_site_id: string | null;
+}


### PR DESCRIPTION
Migrate chargeInfo() to use [V2 endpoint](https://developers.opennode.com/reference/charge-info), for accurate field values.